### PR TITLE
Update request 2.72.x to 2.74.x to fix tough cookie vulnerability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "nconf": "0.8.x",
-    "request": "2.72.x",
+    "request": "2.74.x",
     "devnull": "0.0.x",
     "utile": "0.3.x"
   },


### PR DESCRIPTION
Resolves the vulnerability found in the old version of request.  From Synk scan of an app that relies on stackexchange at  https://snyk.io/test/npm/stack-exchange-markdown-retriever :

"ReDoS via long string of semicolons
high severity

```
Vulnerable module: tough-cookie
Introduced through: stackexchange@0.4.0
```

Detailed paths and remediation

```
Introduced through: stack-exchange-markdown-retriever@1.0.2 › stackexchange@0.4.0 › request@2.72.0 › tough-cookie@2.2.2 Remediation: Run snyk wizard to patch tough-cookie@2.2.2.
```

Overview

tough-cookie package versions 0.9.7 through 2.2.2 are vulnerable to a Regular expression Denial of Service (ReDoS) when long strings of semicolons in the Set-Cookie header, causes the event loop to block for excessive amounts of time.

"The Regular expression Denial of Service (ReDoS) is a Denial of Service attack, that exploits the fact that most Regular Expression implementations may reach extreme situations that cause them to work very slowly (exponentially related to input size). An attacker can then cause a program using a Regular Expression to enter these extreme situations and then hang for a very long time." 1"
