### PR TITLE
Changed `devnull` dependency to a specific commit to get fix for EventEmitter issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "url": "git@github.com:Moveo/stackexchange.git"
   },
   "dependencies": {
+    "devnull": "git+https://github.com/observing/devnull.git#ff99281602feca0cf3bdf0e6d36fedbf1b566523",
     "nconf": "0.8.x",
     "request": "2.72.x",
-    "devnull": "0.0.x",
     "utile": "0.3.x"
   },
   "devDependencies": {


### PR DESCRIPTION
This changes the version of `devnull` in `package.json` in order to get the change introduced in [this PR](https://github.com/observing/devnull/pull/4).
This allows `stackexchange` to be used with Node v. 7.x.x and addresses #10.