### PR TITLE
Flexibility to query other stackexchange websites added

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,14 @@ context.users.users(filter, function(err, results){
   console.log(results.has_more);
 });
 
+// Get results for a different website within the stackexchange network
+filter.site = 'softwareengineering' // this value should be one that is acceptable by the stack exchange API.
+                                    // more details on this can be found on https://api.stackexchange.com/docs
+context.questions.questions(filter, function(err, results){
+  if (err) throw err;
+  
+  console.log(results.items);
+  console.log(results.has_more);
+});
+// the above operation can be done by adding a 'site' key value pair within the options object initialised earlier.
 ```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ context.questions.questions(filter, function(err, results){
   console.log(results.has_more);
 });
 
+// Get results for a different website within the stackexchange network
+filter.site = 'softwareengineering';
+context.questions.questions(filter, function(err, results){
+  if (err) throw err;
+  
+  console.log(results.items);
+  console.log(results.has_more);
+});
+
 // Get all users
 context.users.users(filter, function(err, results){
   if (err) throw err;
@@ -42,15 +51,4 @@ context.users.users(filter, function(err, results){
   console.log(results.items);
   console.log(results.has_more);
 });
-
-// Get results for a different website within the stackexchange network
-filter.site = 'softwareengineering' // this value should be one that is acceptable by the stack exchange API.
-                                    // more details on this can be found on https://api.stackexchange.com/docs
-context.questions.questions(filter, function(err, results){
-  if (err) throw err;
-  
-  console.log(results.items);
-  console.log(results.has_more);
-});
-// the above operation can be done by adding a 'site' key value pair within the options object initialised earlier.
 ```

--- a/lib/query.js
+++ b/lib/query.js
@@ -16,8 +16,8 @@ var config = require('./config')
 module.exports = function query (destination, criteria, callback) {
   if (!callback) throw new Error('No callback supplied for: ' +  destination);
 
-  // Query against the predefined website and construct the endpoint.
-  criteria.site = config.get('site');
+  // Query against the passed site parameter or the predefined website and construct the endpoint.
+  criteria.site = criteria.site || config.get('site');
   var endpoint = url.format({
       protocol: config.get('protocol')
     , host: config.get('api')

--- a/test/questions-test.js
+++ b/test/questions-test.js
@@ -1,0 +1,40 @@
+/*tags expect*/
+
+var stackexchange = require('../lib/stackexchange');
+
+describe('Questions', function () {
+  'use strict';
+
+  var options, context, filter;
+
+  beforeEach(function() {
+    options = { version: 2.2 };
+    context = new stackexchange(options);
+    filter = {
+      pagesize: 10,
+      sort: 'activity',
+      order: 'asc'
+    };
+  });
+
+  it('get questions', function(done) {
+    context.questions.questions(filter, function(err, results){
+      if (err) throw err;
+      expect(results.items).to.have.length(10);
+      expect(results.has_more).to.be.true;
+      expect(results.items.every((val) => val.link.startsWith('https://stackoverflow.com/questions/'))).to.be.true;
+      done();
+    });
+  });
+
+  it('use a different site via filter', function(done) {
+    filter.site = 'softwareengineering';
+    context.questions.questions(filter, function(err, results){
+      if (err) throw err;
+      expect(results.items).to.have.length(10);
+      expect(results.has_more).to.be.true;
+      expect(results.items.every((val) => val.link.startsWith('https://softwareengineering.stackexchange.com/questions/'))).to.be.true;
+      done();
+    });    
+  })
+});


### PR DESCRIPTION
Users would be able to query to every website that are within the stackexchange network.
Do let me know if there is something else to be done to allow this.
A possible error would be if the developer passes an invalid value for the site parameter but that would be handled by the error response returned by the stack exchange API.
Do let me know if there's something else to be done in this request.