### PR TITLE
chore: add currently supported Node.js versions to test matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [10.x, 12.x, 14.x, 15.x, 16.x, 17.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Adding Node.js 16.x and 17.x.